### PR TITLE
Initial script to create tables in database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # movie-reservation-system
+
+### Local Development
+Run a command to run all Docker containers:
+```shell
+docker compose up
+```
+
+Run a command to build and run all Docker containers:
+```shell
+docker compose up --build
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,17 +4,17 @@ services:
     #scripts and commands to be added here or in dockerfiles of each service
     image: postgres:latest
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
       - "5432:5432"
     environment:
       #env vars here (user,db,secrets ...etc)
-      POSTGRES_DB: tba
-      POSTGRES_USER: tba
-      POSTGRES_PASSWORD: tba
+      POSTGRES_DB: postgres
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: password
     healthcheck:
       #db name to be modified
-      test: ["CMD-SHELL", "pg_isready -q -d mydatabase -U myuser"]
+      test: ["CMD-SHELL", "pg_isready -q -d postgres -U admin"]
       interval: 10s
       retries: 5
       start_period: 30s

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,57 @@
+CREATE TABLE "user"
+(
+    id       INT GENERATED ALWAYS AS IDENTITY,
+    username VARCHAR NOT NULL,
+    password VARCHAR NOT NULL,
+    role     VARCHAR NOT NULL,
+    iban     VARCHAR,
+
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE theater
+(
+    id      INT GENERATED ALWAYS AS IDENTITY,
+    name    VARCHAR NOT NULL,
+    address VARCHAR,
+
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE movie
+(
+    id          INT GENERATED ALWAYS AS IDENTITY,
+    name        VARCHAR NOT NULL,
+    description VARCHAR,
+
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE schedule
+(
+    id          INT GENERATED ALWAYS AS IDENTITY,
+    theater_id  INT       NOT NULL,
+    movie_id    INT       NOT NULL,
+    time        TIMESTAMP NOT NULL,
+    price       FLOAT     NOT NULL,
+    total_seats INT       NOT NULL,
+
+    PRIMARY KEY (id),
+    FOREIGN KEY (theater_id) REFERENCES theater (id),
+    FOREIGN KEY (movie_id) REFERENCES movie (id)
+);
+
+CREATE TABLE reservation
+(
+    id           INT GENERATED ALWAYS AS IDENTITY,
+    schedule_id  INT       NOT NULL,
+    user_id      INT       NOT NULL,
+    seats        VARCHAR   NOT NULL,
+    create_time  TIMESTAMP NOT NULL,
+    total_amount FLOAT     NOT NULL,
+    paid         BOOLEAN   NOT NULL,
+
+    PRIMARY KEY (id),
+    FOREIGN KEY (schedule_id) REFERENCES schedule (id),
+    FOREIGN KEY (user_id) REFERENCES "user" (id)
+);


### PR DESCRIPTION
Added an initial script file (`init.sql`) to create tables in the database. The script will run only once when the database container is created.